### PR TITLE
Fix row insert

### DIFF
--- a/main.js
+++ b/main.js
@@ -135,7 +135,11 @@ window.HandsontableInstance = class {
             }
             for(let r = 0; r < content.length; r++) {
                 for (let c = 0; c < content[r].length; c++) {
-                    contentObject[`c${c}`][r] = content[r][c];
+                    if(content[r][c] == null){
+                        contentObject[`c${c}`][r] = ''
+                    } else {
+                        contentObject[`c${c}`][r] = content[r][c];
+                    }
                 }
             }
         }


### PR DESCRIPTION
Inserting a row through contextual menu, generates nulls at the end of each column, which aren't read properly by R, resulting in a failed dataframe conversion when receiving the object.
Fix by replacing nulls by empty strings.